### PR TITLE
#9: 採点画面のUIを実装した

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^5.0.8",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18"
@@ -134,6 +136,59 @@
       },
       "engines": {
         "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
+      "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^5.0.8",
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18"

--- a/src/app/events/[id]/scores/new/Board.jsx
+++ b/src/app/events/[id]/scores/new/Board.jsx
@@ -18,7 +18,7 @@ import {
 
 import { SortableItem } from "./SortableItem";
 
-const Board = () => {
+const Board = (props) => {
   const [items, setItems] = useState([1, 2, 3]);
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -46,13 +46,15 @@ const Board = () => {
       collisionDetection={closestCenter}
       onDragEnd={handleDragEnd}
     >
-      <SortableContext items={items} strategy={verticalListSortingStrategy}>
-        {items.map((id) => (
-          <SortableItem key={id} id={id}>
-            {id}
-          </SortableItem>
-        ))}
-      </SortableContext>
+      <ol className="board" key={props.id}>
+        <SortableContext items={items} strategy={verticalListSortingStrategy}>
+          {items.map((id) => (
+            <li key={id} id={id}>
+              <SortableItem>{id}</SortableItem>
+            </li>
+          ))}
+        </SortableContext>
+      </ol>
     </DndContext>
   );
 };

--- a/src/app/events/[id]/scores/new/Board.jsx
+++ b/src/app/events/[id]/scores/new/Board.jsx
@@ -46,7 +46,7 @@ const Board = ({ name, ...props }) => {
       collisionDetection={closestCenter}
       onDragEnd={handleDragEnd}
     >
-      <ol className="board">
+      <ol id={props.id} className="board">
         <h3>{ name }</h3>
         <SortableContext items={items} strategy={verticalListSortingStrategy}>
           {items.map((id) => (

--- a/src/app/events/[id]/scores/new/Board.jsx
+++ b/src/app/events/[id]/scores/new/Board.jsx
@@ -18,7 +18,7 @@ import {
 
 import { SortableItem } from "./SortableItem";
 
-const Board = () => {
+const Board = (props) => {
   const [items, setItems] = useState([1, 2, 3]);
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -49,9 +49,9 @@ const Board = () => {
       <ol className="board">
         <SortableContext items={items} strategy={verticalListSortingStrategy}>
           {items.map((id) => (
-            <li key={id} id={id}>
-              <SortableItem>{id}</SortableItem>
-            </li>
+            <SortableItem key={id} id={id}>
+              <li>{id}</li>
+            </SortableItem>
           ))}
         </SortableContext>
       </ol>

--- a/src/app/events/[id]/scores/new/Board.jsx
+++ b/src/app/events/[id]/scores/new/Board.jsx
@@ -18,7 +18,7 @@ import {
 
 import { SortableItem } from "./SortableItem";
 
-const Board = (props) => {
+const Board = () => {
   const [items, setItems] = useState([1, 2, 3]);
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -46,7 +46,7 @@ const Board = (props) => {
       collisionDetection={closestCenter}
       onDragEnd={handleDragEnd}
     >
-      <ol className="board" key={props.id}>
+      <ol className="board">
         <SortableContext items={items} strategy={verticalListSortingStrategy}>
           {items.map((id) => (
             <li key={id} id={id}>

--- a/src/app/events/[id]/scores/new/Board.jsx
+++ b/src/app/events/[id]/scores/new/Board.jsx
@@ -18,7 +18,7 @@ import {
 
 import { SortableItem } from "./SortableItem";
 
-const Board = (props) => {
+const Board = ({ name }) => {
   const [items, setItems] = useState([1, 2, 3]);
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -47,6 +47,7 @@ const Board = (props) => {
       onDragEnd={handleDragEnd}
     >
       <ol className="board">
+        <h3>{ name }</h3>
         <SortableContext items={items} strategy={verticalListSortingStrategy}>
           {items.map((id) => (
             <SortableItem key={id} id={id}>

--- a/src/app/events/[id]/scores/new/Board.jsx
+++ b/src/app/events/[id]/scores/new/Board.jsx
@@ -18,8 +18,8 @@ import {
 
 import { SortableItem } from "./SortableItem";
 
-const Board = ({ name }) => {
-  const [items, setItems] = useState([1, 2, 3]);
+const Board = ({ name, ...props }) => {
+  const [items, setItems] = useState(props.items);
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {

--- a/src/app/events/[id]/scores/new/Board.jsx
+++ b/src/app/events/[id]/scores/new/Board.jsx
@@ -1,0 +1,60 @@
+"use client"
+
+import React, { useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+
+import { SortableItem } from "./SortableItem";
+
+const Board = () => {
+  const [items, setItems] = useState([1, 2, 3]);
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+
+    if (active.id !== over.id) {
+      setItems((items) => {
+        const oldIndex = items.indexOf(active.id);
+        const newIndex = items.indexOf(over.id);
+
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+        {items.map((id) => (
+          <SortableItem key={id} id={id}>
+            {id}
+          </SortableItem>
+        ))}
+      </SortableContext>
+    </DndContext>
+  );
+};
+
+export default Board;

--- a/src/app/events/[id]/scores/new/SortableItem.jsx
+++ b/src/app/events/[id]/scores/new/SortableItem.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+export function SortableItem(props) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: props.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {/* ... */}
+    </div>
+  );
+}

--- a/src/app/events/[id]/scores/new/SortableItem.jsx
+++ b/src/app/events/[id]/scores/new/SortableItem.jsx
@@ -6,15 +6,8 @@ export function SortableItem(props) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: props.id });
 
-  const style = {
-    border: "1px solid",
-    transform: CSS.Transform.toString(transform),
-    transition,
-    padding: 16,
-  };
-
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <div className="board__card" ref={setNodeRef} {...attributes} {...listeners}>
       {props.children}
     </div>
   );

--- a/src/app/events/[id]/scores/new/SortableItem.jsx
+++ b/src/app/events/[id]/scores/new/SortableItem.jsx
@@ -7,13 +7,15 @@ export function SortableItem(props) {
     useSortable({ id: props.id });
 
   const style = {
+    border: "1px solid",
     transform: CSS.Transform.toString(transform),
     transition,
+    padding: 16,
   };
 
   return (
     <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      {/* ... */}
+      {props.children}
     </div>
   );
 }

--- a/src/app/events/[id]/scores/new/SortableItem.jsx
+++ b/src/app/events/[id]/scores/new/SortableItem.jsx
@@ -6,8 +6,13 @@ export function SortableItem(props) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: props.id });
 
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
   return (
-    <div className="board__card" ref={setNodeRef} {...attributes} {...listeners}>
+    <div className="board__card" ref={setNodeRef} style={style} {...attributes} {...listeners}>
       {props.children}
     </div>
   );

--- a/src/app/events/[id]/scores/new/page.jsx
+++ b/src/app/events/[id]/scores/new/page.jsx
@@ -10,11 +10,11 @@ const page = () => {
     <>
       <h1>採点する</h1>
       <div className="boards">
-        <Board />
-        <Board />
-        <Board />
-        <Board />
-        <Board />
+        <Board name="つよさ" />
+        <Board name="かっこよさ" />
+        <Board name="かわいさ" />
+        <Board name="ヤバさ" />
+        <Board name="おもしろさ" />
       </div>
     </>
   );

--- a/src/app/events/[id]/scores/new/page.jsx
+++ b/src/app/events/[id]/scores/new/page.jsx
@@ -6,15 +6,38 @@ import React, { useState } from 'react'
 import Board from './Board';
 
 const page = () => {
+  // TODO: チーム一覧情報の取得
+  const teams = [
+    "ねずみ",
+    "うし",
+    "とら",
+    "うさぎ",
+    "りゅう",
+    "へび",
+    "うま",
+    "ひつじ",
+    "さる",
+    "とり",
+    "いぬ",
+    "いのしし",
+  ]
+
+  // TODO: 採点基準一覧の取得
+  const criteria = [
+    { id: "strength", name: "つよさ" },
+    { id: "coolness", name: "かっこよさ" },
+    { id: "cuteness", name: "かわいさ" },
+    { id: "awesomeness", name: "ヤバさ" },
+    { id: "funniness", name: "おもしろさ" },
+  ]
+
   return (
     <>
       <h1>採点する</h1>
       <div className="boards">
-        <Board name="つよさ" />
-        <Board name="かっこよさ" />
-        <Board name="かわいさ" />
-        <Board name="ヤバさ" />
-        <Board name="おもしろさ" />
+        {criteria.map((criterion) => (
+          <Board key={criterion.id} name={criterion.name} items={teams} />
+        ))}
       </div>
     </>
   );

--- a/src/app/events/[id]/scores/new/page.jsx
+++ b/src/app/events/[id]/scores/new/page.jsx
@@ -31,14 +31,32 @@ const page = () => {
     { id: "funniness", name: "おもしろさ" },
   ]
 
+  const handleSubmit = () => {
+    // 各ボードの順位を取得
+    const rankings = criteria.map((criterion) => {
+      const board = document.getElementById(criterion.id)
+      const items = Array.from(board.children).map((item) => item.textContent)
+      return { criterion: criterion.id, ranking: items }
+    })
+
+    // TODO: ランキング情報を送信
+    console.log(rankings)
+  }
+
   return (
     <>
       <h1>採点する</h1>
       <div className="boards">
         {criteria.map((criterion) => (
-          <Board key={criterion.id} name={criterion.name} items={teams} />
+          <Board
+            id={criterion.id}
+            key={criterion.id}
+            name={criterion.name}
+            items={teams}
+          />
         ))}
       </div>
+      <button onClick={handleSubmit}>確定する！</button>
     </>
   );
 }

--- a/src/app/events/[id]/scores/new/page.jsx
+++ b/src/app/events/[id]/scores/new/page.jsx
@@ -1,60 +1,19 @@
 "use client"
 
 import React, { useState } from 'react'
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { SortableItem } from './SortableItem';
+import Board from './Board';
 
 const page = () => {
-  const [items, setItems] = useState([1, 2, 3]);
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
-  );
-
   return (
     <>
       <h1>採点する</h1>
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext items={items} strategy={verticalListSortingStrategy}>
-          {items.map((id) => (
-            <SortableItem key={id} id={id}>{id}</SortableItem>
-          ))}
-        </SortableContext>
-      </DndContext>
+      <div className="boards">
+        <Board />
+        <Board />
+        <Board />
+      </div>
     </>
   );
-
-  function handleDragEnd(event) {
-    const { active, over } = event;
-
-    if (active.id !== over.id) {
-      setItems((items) => {
-        const oldIndex = items.indexOf(active.id);
-        const newIndex = items.indexOf(over.id);
-
-        return arrayMove(items, oldIndex, newIndex);
-      });
-    }
-  }
 }
 
 export default page

--- a/src/app/events/[id]/scores/new/page.jsx
+++ b/src/app/events/[id]/scores/new/page.jsx
@@ -1,5 +1,7 @@
 "use client"
 
+import "./style.css"
+
 import React, { useState } from 'react'
 import Board from './Board';
 
@@ -8,9 +10,11 @@ const page = () => {
     <>
       <h1>採点する</h1>
       <div className="boards">
-        <Board />
-        <Board />
-        <Board />
+        <Board id="1" />
+        <Board id="2" />
+        <Board id="3" />
+        <Board id="4" />
+        <Board id="5" />
       </div>
     </>
   );

--- a/src/app/events/[id]/scores/new/page.jsx
+++ b/src/app/events/[id]/scores/new/page.jsx
@@ -10,11 +10,11 @@ const page = () => {
     <>
       <h1>採点する</h1>
       <div className="boards">
-        <Board id="1" />
-        <Board id="2" />
-        <Board id="3" />
-        <Board id="4" />
-        <Board id="5" />
+        <Board />
+        <Board />
+        <Board />
+        <Board />
+        <Board />
       </div>
     </>
   );

--- a/src/app/events/[id]/scores/new/page.jsx
+++ b/src/app/events/[id]/scores/new/page.jsx
@@ -1,11 +1,60 @@
-import React from 'react'
+"use client"
+
+import React, { useState } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { SortableItem } from './SortableItem';
 
 const page = () => {
+  const [items, setItems] = useState([1, 2, 3]);
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
   return (
     <>
       <h1>採点する</h1>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={items} strategy={verticalListSortingStrategy}>
+          {items.map((id) => (
+            <SortableItem key={id} id={id}>{id}</SortableItem>
+          ))}
+        </SortableContext>
+      </DndContext>
     </>
-  )
+  );
+
+  function handleDragEnd(event) {
+    const { active, over } = event;
+
+    if (active.id !== over.id) {
+      setItems((items) => {
+        const oldIndex = items.indexOf(active.id);
+        const newIndex = items.indexOf(over.id);
+
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  }
 }
 
 export default page

--- a/src/app/events/[id]/scores/new/style.css
+++ b/src/app/events/[id]/scores/new/style.css
@@ -1,8 +1,32 @@
 .boards {
-    display: flex;
-    gap: 1rem;
+  display: flex;
+  gap: 1rem;
+
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  background-color: #eee;
+
+  padding: 1rem;
 }
 
 .board {
-  flex: 1;
+  text-align: center;
+  width: 250px;
+  border: 1px solid #ccc;
+  border-radius: 10px;
+
+  padding: 2rem;
+}
+
+.board__card {
+  text-align: center;
+  user-select: none;
+  list-style-position: outside;
+
+  background-color: rgba(255, 255, 255, 0.7);
+  border: 1px solid #ccc;
+  border-radius: 10px;
+
+  margin: 1rem 0;
+  padding: 1rem 0;
 }

--- a/src/app/events/[id]/scores/new/style.css
+++ b/src/app/events/[id]/scores/new/style.css
@@ -4,7 +4,7 @@
 
   border: 1px solid #ccc;
   border-radius: 10px;
-  background-color: #eee;
+  background-color: #ddd;
   width: max-content;
   overflow-x: auto;
 
@@ -15,6 +15,7 @@
   text-align: center;
   width: 250px;
   border: 1px solid #ccc;
+  background-color: #eee;
   border-radius: 10px;
 
   padding: 2rem;

--- a/src/app/events/[id]/scores/new/style.css
+++ b/src/app/events/[id]/scores/new/style.css
@@ -1,0 +1,8 @@
+.boards {
+    display: flex;
+    gap: 1rem;
+}
+
+.board {
+  flex: 1;
+}

--- a/src/app/events/[id]/scores/new/style.css
+++ b/src/app/events/[id]/scores/new/style.css
@@ -5,6 +5,8 @@
   border: 1px solid #ccc;
   border-radius: 10px;
   background-color: #eee;
+  width: max-content;
+  overflow-x: auto;
 
   padding: 1rem;
 }


### PR DESCRIPTION
## チケット
issue: #9

## やったこと
- 採点ページのUIを作成した
  - 各採点項目ごとにチームを並び替えできるボードを作成

## 確認して欲しいこと
- UIが正常に動作するか
  - 各ボードの要素が垂直に並び替えできるか

## 検証方法
- `npm install` する（dnd-kit のインストール）
- サーバ起動、http://localhost:3000/events/1/scores/new にアクセス
- いじる

## やらないこと
- デザイン（あとでやる）

## その他なにか気づいたこと
- API 送信時には、各boardのstateをとりまとめて送信するのではなく、DOMとして各ボードの中のリストを順序付きで取得するのがよさそう